### PR TITLE
keywords with spaces in between

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ chmod +x bbid.py
 ```
 ### Example
 `./bbid.py -s earth`
+`./bbid.py -s hello+earth` for more than one word.


### PR DESCRIPTION
added an example explaining the usage of `+` in between the words instead of spaces.
